### PR TITLE
Implement MCP client connection in orchestrator

### DIFF
--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -8,9 +8,11 @@
 //
 // Startup target: <500ms for new sessions
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use tracing::{info, Level};
+use ironclaw_orchestrator::mcp::{McpClient, StdioTransport};
+use serde_json::json;
+use tracing::{error, info, Level};
 use tracing_subscriber::EnvFilter;
 
 /// IronClaw: Local-first Agentic AI Runtime
@@ -39,7 +41,19 @@ enum Commands {
     /// Spawn a new JIT Micro-VM
     SpawnVm,
     /// Test MCP connection
-    TestMcp,
+    TestMcp {
+        /// Command to spawn the MCP server (default: "npx" with filesystem server)
+        #[arg(long)]
+        command: Option<String>,
+
+        /// Arguments for the MCP server
+        #[arg(long, num_args = 0.., value_delimiter = ' ', allow_hyphen_values = true)]
+        args: Vec<String>,
+
+        /// Only list tools, do not call any
+        #[arg(long)]
+        list_tools: bool,
+    },
 }
 
 #[tokio::main]
@@ -74,9 +88,13 @@ async fn main() -> Result<()> {
             info!("Spawning JIT Micro-VM...");
             spawn_vm().await?;
         }
-        Some(Commands::TestMcp) => {
+        Some(Commands::TestMcp {
+            command,
+            args,
+            list_tools,
+        }) => {
             info!("Testing MCP connection...");
-            test_mcp().await?;
+            test_mcp(command, args, list_tools).await?;
         }
         None => {
             info!("No command specified. Use 'ironclaw --help' for usage.");
@@ -113,13 +131,107 @@ async fn spawn_vm() -> Result<()> {
 }
 
 /// Test MCP (Model Context Protocol) connection
-async fn test_mcp() -> Result<()> {
-    info!("🔌 Testing MCP connection...");
-    // TODO: Implement MCP client
+async fn test_mcp(command: Option<String>, args: Vec<String>, list_tools_only: bool) -> Result<()> {
+    // Determine command and args
+    let (cmd, cmd_args) = if let Some(c) = command {
+        (c, args)
+    } else if !args.is_empty() {
+        ("npx".to_string(), args)
+    } else {
+        // Default to npx filesystem server
+        // Using `.` as the allowed directory so we can read Cargo.toml
+        (
+            "npx".to_string(),
+            vec![
+                "-y".to_string(),
+                "@modelcontextprotocol/server-filesystem".to_string(),
+                ".".to_string(),
+            ],
+        )
+    };
+
+    // Prepare string slices for spawn
+    let args_slices: Vec<&str> = cmd_args.iter().map(|s| s.as_str()).collect();
+
+    info!("🔌 Connecting to MCP server: {} {:?}", cmd, args_slices);
+
     // 1. Connect to MCP server
+    let transport = match StdioTransport::spawn(&cmd, &args_slices).await {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Failed to spawn MCP server '{}': {}", cmd, e);
+            if cmd == "npx" {
+                info!("Tip: Make sure Node.js and npx are installed and available in your PATH.");
+            }
+            return Err(e);
+        }
+    };
+
+    let mut client = McpClient::new(transport);
+
+    info!("Initializing MCP client...");
+    client
+        .initialize()
+        .await
+        .context("Failed to initialize MCP client")?;
+
+    info!("MCP client initialized successfully!");
+    if let Some(caps) = client.server_capabilities() {
+        info!(
+            "Server: {} v{}",
+            caps.server_info.name, caps.server_info.version
+        );
+    }
+
     // 2. List available tools
+    info!("Listing available tools...");
+    let tools = client.list_tools().await.context("Failed to list tools")?;
+
+    info!("Found {} tools:", tools.len());
+    for tool in &tools {
+        info!("  - {}: {}", tool.name, tool.description);
+    }
+
+    if list_tools_only {
+        return Ok(());
+    }
+
     // 3. Test tool execution
-    println!("MCP connection test placeholder");
+    // If using the default filesystem server, try to read Cargo.toml
+    if cmd == "npx" && tools.iter().any(|t| t.name == "read_file") {
+        info!("Testing 'read_file' tool with Cargo.toml...");
+        match client
+            .call_tool("read_file", json!({"path": "Cargo.toml"}))
+            .await
+        {
+            Ok(result) => {
+                info!("Tool execution successful!");
+                // The result from read_file usually contains "content"
+                if let Some(content) = result.get("content").and_then(|c| c.as_array()) {
+                    if let Some(first) = content.first() {
+                        if let Some(text) = first.get("text").and_then(|t| t.as_str()) {
+                            // Print first few lines
+                            let preview: String =
+                                text.lines().take(5).collect::<Vec<_>>().join("\n");
+                            println!("--- Cargo.toml preview ---\n{}\n...", preview);
+                        }
+                    }
+                } else {
+                    println!("Result: {:?}", result);
+                }
+            }
+            Err(e) => {
+                error!("Tool execution failed: {}", e);
+                return Err(e);
+            }
+        }
+    } else if !tools.is_empty() {
+        // Just print a message for other servers
+        info!("Skipping tool execution test (no known test tool found or not using default server). Use specific arguments to test tools.");
+    } else {
+        info!("No tools available to test.");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Implemented the `test_mcp` command in `orchestrator/src/main.rs`.
- Updated `Commands::TestMcp` to accept optional `command`, `args`, and `list_tools` flags.
- Implemented `test_mcp` function to connect to an MCP server (defaults to `npx -y @modelcontextprotocol/server-filesystem .`).
- Connects using `StdioTransport`, initializes `McpClient`, lists tools, and optionally executes `read_file` on `Cargo.toml` for verification.
- Handles default argument logic correctly to allow user overrides.
- Verified with `cargo run` and existing tests.

---
*PR created automatically by Jules for task [16336613908620301000](https://jules.google.com/task/16336613908620301000) started by @anchapin*

## Summary by Sourcery

Add a configurable MCP test command that connects to an MCP server, lists tools, and optionally exercises a filesystem tool for verification.

New Features:
- Allow the TestMcp CLI command to specify a custom MCP server command, arguments, and a flag to only list tools.
- Implement an MCP client test routine that spawns an MCP server over stdio, initializes the client, lists available tools, and optionally calls a tool for validation.