### PR TITLE
Implement Firecracker VM process management

### DIFF
--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -46,6 +46,7 @@ uuid = { version = "1.0", features = ["v4"] }
 hyper = { version = "1.8.1", features = ["full"] }
 hyper-util = { version = "0.1.20", features = ["client", "http1", "client-legacy"] }
 http-body-util = "0.1.3"
+bytes = "1.9"
 tower-service = "0.3.3"
 chrono = { version = "0.4.43", features = ["serde"] }
 


### PR DESCRIPTION
Implemented the Firecracker VM process management logic. This includes spawning the Firecracker process, waiting for the API socket, and configuring the VM (boot source, machine config, start instance) via HTTP over the Unix socket using `hyper` and `hyper-util`. Also implemented robust cleanup logic for the process and socket file.

---
*PR created automatically by Jules for task [5478936793134984403](https://jules.google.com/task/5478936793134984403) started by @anchapin*

## Summary by Sourcery

Implement Firecracker VM lifecycle management within the orchestrator, including spawning, configuring, and stopping Firecracker VMs via the API Unix socket.

New Features:
- Add FirecrackerProcess struct to represent a running Firecracker VM, including PID, API socket path, and spawn timing metadata.
- Implement asynchronous start_firecracker function that launches the Firecracker binary, waits for its API socket, and configures the VM via HTTP calls over a Unix domain socket based on VmConfig.
- Implement asynchronous stop_firecracker function to terminate the Firecracker process and clean up the associated API socket file.
- Introduce a UnixConnector service and Hyper-based client setup to communicate with Firecracker's Unix socket API for boot source, machine configuration, and instance start actions.
- Expose the vm module from the orchestrator crate to make Firecracker integration available externally.

Enhancements:
- Add Drop implementation for FirecrackerProcess to ensure best-effort cleanup of the Firecracker process and its API socket file on struct drop.
- Extend orchestrator dependencies with Hyper, Hyper-Util, HTTP body utilities, Tower Service, and Chrono to support HTTP-over-Unix-socket communication and future time-related functionality.

Build:
- Add networking and HTTP-related dependencies (hyper, hyper-util, http-body-util, tower-service, chrono) to orchestrator Cargo.toml for Firecracker process management and communication.

Tests:
- Add a unit test verifying that dropping FirecrackerProcess removes the API socket file when present.