### PR TITLE
refactor(agent): remove redundant imports in mcp_client.py

### DIFF
--- a/agent/mcp_client.py
+++ b/agent/mcp_client.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import time
 from typing import Any, Dict, List, Optional
 from dataclasses import dataclass
 from enum import Enum
@@ -145,7 +146,7 @@ class McpClient:
             raise McpError("All command arguments must be strings")
 
         # Check for shell metacharacters that could enable injection
-        shell_metachars = [';', '&', '|', '$', '`', '(', ')', '<', '>', '\n', '\r']
+        shell_metachars = [";", "&", "|", "$", "`", "(", ")", "<", ">", "\n", "\r"]
         for arg in command:
             if any(char in arg for char in shell_metachars):
                 raise McpError(
@@ -157,26 +158,26 @@ class McpClient:
         # This is not a security boundary (the subprocess runs locally as the user),
         # but prevents accidental mistakes and documents expected commands.
         safe_commands = {
-            'npx',           # Node.js package runner
-            'python', 'python3',  # Python interpreters
-            'node',          # Node.js runtime
-            'cargo',         # Rust toolchain (for testing)
-            'echo',          # Testing (benign)
-            'true',          # Testing (benign)
-            'cat',           # File operations (for trusted input)
+            "npx",  # Node.js package runner
+            "python",
+            "python3",  # Python interpreters
+            "node",  # Node.js runtime
+            "cargo",  # Rust toolchain (for testing)
+            "echo",  # Testing (benign)
+            "true",  # Testing (benign)
+            "cat",  # File operations (for trusted input)
         }
 
         base_cmd = command[0]
         # Allow paths (e.g., ./node_modules/.bin/npx) by checking base name
-        base_name = base_cmd.split('/')[-1].split('\\')[-1]
+        base_name = base_cmd.split("/")[-1].split("\\")[-1]
 
         if base_name not in safe_commands:
             # Log warning but don't fail - user may have custom setup
-            import sys
             print(
                 f"Warning: Command '{base_name}' not in known-safe list. "
                 f"Ensure this command is trusted and does not accept untrusted input.",
-                file=sys.stderr
+                file=sys.stderr,
             )
 
         return command
@@ -282,8 +283,6 @@ class McpClient:
 
         # Wait briefly for process to start
         # (In production, would check if process is ready)
-        import time
-
         time.sleep(0.1)
 
         self._state = McpState.CONNECTED
@@ -431,7 +430,6 @@ def main():
     Usage:
         python -m agent.mcp_client
     """
-    import sys
     import tempfile
 
     print("IronClaw MCP Client - Test")


### PR DESCRIPTION
🧹 **Code Health Improvement**

**What:**
- Moved `import time` from the `spawn` method to top-level imports in `agent/mcp_client.py`.
- Removed redundant `import sys` from `_validate_command` and `main` functions in `agent/mcp_client.py`.

**Why:**
- Moving standard library imports to the top level improves readability and consistency.
- Removing redundant imports reduces code clutter.

**Verification:**
- ✅ Ran `make test-python`: 83 tests passed.
- ✅ Ran `make lint`: Checked for linting issues (pre-existing ones noted but out of scope).
- ✅ Ran `make fmt`: Code is formatted with `black`.

**Result:**
- Cleaner, more standard Python code in `agent/mcp_client.py`.

---
*PR created automatically by Jules for task [16003931524796727242](https://jules.google.com/task/16003931524796727242) started by @anchapin*