### PR TITLE
docs: Add review for PR #41

### DIFF
--- a/PR_REVIEW_41.md
+++ b/PR_REVIEW_41.md
@@ -1,0 +1,35 @@
+# Review for PR #41: Refactor path parsing in mcp_client.py
+
+**Summary:**
+This PR refactors the command validation logic in `agent/mcp_client.py` to use `pathlib.Path` for extracting the base command name, replacing manual string splitting. This improves code quality and readability.
+
+**Findings:**
+
+🔴 **Critical: Formatting Check Failed**
+The changes do not adhere to the project's code style (checked with `black`). The pre-commit hooks failed.
+Please run `make fmt` or `black agent/mcp_client.py` to fix the formatting issues.
+
+```python
+# black --diff output (truncated)
+-        shell_metachars = [';', '&', '|', '$', '`', '(', ')', '<', '>', '\n', '\r']
++        shell_metachars = [";", "&", "|", "$", "`", "(", ")", "<", ">", "\n", "\r"]
+...
+-            'npx',           # Node.js package runner
++            "npx",  # Node.js package runner
+```
+
+💡 **Suggestion: Cross-Platform Path Handling**
+The use of `pathlib.Path(base_cmd).name` is stricter than the previous implementation as it relies on the operating system's path separator.
+- On Linux, `Path('.\node_modules\.bin\npx').name` evaluates to the full string `.\node_modules\.bin\npx` (treated as a filename with backslashes), whereas the old logic extracted `npx`.
+- This is technically correct for `subprocess.Popen` on Linux, but may cause warnings if Windows-style paths are provided in configuration. Given that cross-platform execution of paths is generally not supported without translation, this change is acceptable and likely safer.
+
+💡 **Suggestion: Type Hints**
+While unrelated to this PR, `agent/mcp_client.py` has several existing `mypy` errors (e.g., `Item "None" of "Popen[Any] | None" has no attribute "stdin"`). Consider addressing these in a future PR or if you touch related code.
+
+**Testing:**
+- ✅ Existing tests passed, including `test_handles_path_to_safe_command`.
+- ✅ Coverage is maintained.
+- ✅ `loop.py` line count invariant is preserved.
+
+**Recommendation:**
+**Request Changes** - Please fix the formatting issues identified by `black`.

--- a/agent/mcp_client.py
+++ b/agent/mcp_client.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 from dataclasses import dataclass
 from enum import Enum
@@ -168,7 +169,7 @@ class McpClient:
 
         base_cmd = command[0]
         # Allow paths (e.g., ./node_modules/.bin/npx) by checking base name
-        base_name = base_cmd.split('/')[-1].split('\\')[-1]
+        base_name = Path(base_cmd).name
 
         if base_name not in safe_commands:
             # Log warning but don't fail - user may have custom setup


### PR DESCRIPTION
# Review for PR #41: Refactor path parsing in mcp_client.py

**Summary:**
This PR refactors the command validation logic in `agent/mcp_client.py` to use `pathlib.Path` for extracting the base command name, replacing manual string splitting. This improves code quality and readability.

**Findings:**

🔴 **Critical: Formatting Check Failed**
The changes do not adhere to the project's code style (checked with `black`). The pre-commit hooks failed.
Please run `make fmt` or `black agent/mcp_client.py` to fix the formatting issues.

```python
# black --diff output (truncated)
-        shell_metachars = [';', '&', '|', '$', '`', '(', ')', '<', '>', '\n', '\r']
+        shell_metachars = [";", "&", "|", "$", "`", "(", ")", "<", ">", "\n", "\r"]
...
-            'npx',           # Node.js package runner
+            "npx",  # Node.js package runner
```

💡 **Suggestion: Cross-Platform Path Handling**
The use of `pathlib.Path(base_cmd).name` is stricter than the previous implementation as it relies on the operating system's path separator.
- On Linux, `Path('.\node_modules\.bin\npx').name` evaluates to the full string `.\node_modules\.bin\npx` (treated as a filename with backslashes), whereas the old logic extracted `npx`.
- This is technically correct for `subprocess.Popen` on Linux, but may cause warnings if Windows-style paths are provided in configuration. Given that cross-platform execution of paths is generally not supported without translation, this change is acceptable and likely safer.

💡 **Suggestion: Type Hints**
While unrelated to this PR, `agent/mcp_client.py` has several existing `mypy` errors (e.g., `Item "None" of "Popen[Any] | None" has no attribute "stdin"`). Consider addressing these in a future PR or if you touch related code.

**Testing:**
- ✅ Existing tests passed, including `test_handles_path_to_safe_command`.
- ✅ Coverage is maintained.
- ✅ `loop.py` line count invariant is preserved.

**Recommendation:**
**Request Changes** - Please fix the formatting issues identified by `black`.

---
*PR created automatically by Jules for task [8299827984010446643](https://jules.google.com/task/8299827984010446643) started by @anchapin*