### PR TITLE
docs: Add review for PR #113

### DIFF
--- a/PR_REVIEW_113.md
+++ b/PR_REVIEW_113.md
@@ -1,0 +1,44 @@
+# Review for PR #113: Fix dangerous PR #111 and correct review findings
+
+**Summary of changes**
+The PR adds `PR_REVIEW_107_JULES.md`, which provides a corrected review of PR #107. It aims to fix inaccuracies in a previous review, such as removing incorrect claims about path injection and type hints, while retaining valid findings.
+
+**Potential Issues**
+
+**1. Inaccurate Finding on DoS Vulnerability (🟡 Warning)**
+The added review file `PR_REVIEW_107_JULES.md` retains the following finding:
+> **DoS Vulnerability (Seccomp):** `SeccompAuditLog` in `orchestrator/src/vm/seccomp.rs` grows indefinitely (`entries: Vec<SeccompAuditEntry>`).
+
+However, examination of `orchestrator/src/vm/seccomp.rs` in the current codebase reveals that `SeccompAuditLog` uses `VecDeque` with a fixed capacity limit (`MAX_SECCOMP_LOG_ENTRIES = 10000`):
+
+```rust
+pub struct SeccompAuditLog {
+    entries: Arc<RwLock<VecDeque<SeccompAuditEntry>>>,
+    // ...
+}
+
+// ... in log_blocked_syscall ...
+        if entries.len() >= MAX_SECCOMP_LOG_ENTRIES {
+            entries.pop_front();
+        }
+```
+This finding appears to be stale or incorrect for the current version of the code (likely fixed in PR #108). Please update the review to reflect that this issue has been addressed.
+
+**2. Dead Code / Unlinked Module (🔴 Critical)**
+The review correctly identifies missing tests, but misses a more fundamental issue: the entire `vm` module is dead code.
+- `orchestrator/src/lib.rs` does not contain `pub mod vm;`.
+- `orchestrator/src/main.rs` does not contain `mod vm;`.
+- As a result, `orchestrator/src/vm/mod.rs` and its submodules (`firecracker`, `seccomp`, `config`) are never compiled or linked into the binary.
+- This explains why `cargo test vm` returns 0 tests (except for the placeholder in `main.rs`) - the actual VM tests are not being compiled.
+- This also means any coverage metrics reported for the `vm` module (e.g., in `CLAUDE.md`) are likely misleading as the code is excluded from compilation.
+
+**3. Valid Findings Confirmed**
+- **Missing Tests:** The finding that `orchestrator/src/vm/tests.rs` is missing is correct.
+- **Incomplete Implementation:** The finding that `firecracker.rs` contains placeholder logic is correct.
+- **Fragile XML Parsing:** The finding regarding `agent/loop.py` regex parsing is valid.
+
+**Decision**
+**Request Changes** to `PR_REVIEW_107_JULES.md` to:
+1.  Mark the DoS vulnerability as **Fixed** or remove it.
+2.  Add a finding about the **Dead Code** issue (VM module unlinked).
+3.  Reiterate the need to restore `orchestrator/src/vm/tests.rs` and properly link the module in `lib.rs` or `main.rs`.


### PR DESCRIPTION
Adds `PR_REVIEW_113.md` detailing findings on PR #113.
Identifies that the DoS vulnerability mentioned in the PR is actually fixed in the current codebase.
Identifies a critical issue where the `orchestrator/src/vm` module is not linked in `lib.rs` or `main.rs`, rendering it dead code.

---
*PR created automatically by Jules for task [12886195041825697671](https://jules.google.com/task/12886195041825697671) started by @anchapin*