### PR TITLE
fix: Link VM module and resolve firewall/compilation issues (Review PR #68)

### DIFF
--- a/PR_REVIEW_68_JULES.md
+++ b/PR_REVIEW_68_JULES.md
@@ -1,0 +1,48 @@
+# Review of PR #68: Identify Critical Collision Vulnerability
+
+**Author**: Jules (Google Labs)
+**Date**: 2026-02-12
+
+## Summary
+
+This review covers PR #68, which aims to resolve a critical chain name collision vulnerability in the firewall module. While the proposed fix (deterministic hashing) is sound, I have identified several **critical** issues that render the fix ineffective and introduce new risks.
+
+## Critical Findings 🔴
+
+### 1. VM Module is Dead Code (Unlinked)
+The `orchestrator/src/vm` module is **not linked** in `orchestrator/src/lib.rs` or `orchestrator/src/main.rs`.
+- **Impact**: The entire VM module, including the firewall fix, is **not compiled**.
+- **Evidence**: `orchestrator/src/lib.rs` only contains `pub mod mcp;`.
+- **Recommendation**: Add `pub mod vm;` to `orchestrator/src/lib.rs` to enable compilation and testing.
+
+### 2. Firewall Module is Dead Code (Unlinked)
+Even if `vm` were linked, `orchestrator/src/vm/firewall.rs` is **not linked** in `orchestrator/src/vm/mod.rs`.
+- **Impact**: The firewall logic (including the collision fix) is dead code.
+- **Recommendation**: Add `pub mod firewall;` to `orchestrator/src/vm/mod.rs`.
+
+### 3. Firewall is Fail-Open
+The `FirewallManager::configure_isolation` method creates a chain and adds rules but **fails to link** the chain to the system's `FORWARD` or `INPUT` chains.
+- **Impact**: Traffic never reaches the isolation chain, rendering the firewall useless (fail-open).
+- **Evidence**: `verify_isolation` correctly returns `false` because no jump rule exists.
+- **Recommendation**: Implement `link_chain` to add a jump rule (e.g., `iptables -I FORWARD -j <CHAIN>`) and ensure it is called during configuration.
+
+### 4. Firecracker Integration is Broken
+The `orchestrator/src/vm/firecracker.rs` file has multiple issues:
+- **Missing Imports**: Essential types like `Child`, `Path`, `info`, `debug` are used but not imported.
+- **Signature Mismatch**: `start_firecracker` is defined as taking `&str` but called with `&VmConfig` in `mod.rs`.
+- **Impact**: The code will fail to compile once the module is linked.
+- **Recommendation**: Fix imports and update function signature to `pub async fn start_firecracker(_config: &VmConfig) -> Result<FirecrackerProcess>`.
+
+### 5. Seccomp Code Quality
+- **Duplicate Constants**: `MAX_SECCOMP_LOG_ENTRIES` is defined twice in `orchestrator/src/vm/seccomp.rs`.
+- **Duplicate Tests**: `test_audit_log_capacity_limit` and `test_audit_log_limit` are identical.
+- **Impact**: Compiler warnings (or errors) and maintenance confusion.
+- **Recommendation**: Remove duplicates.
+
+## Verification
+
+I have verified `agent/loop.py` complies with the 4,000 LOC limit (current: 396 lines).
+
+## Conclusion
+
+**Request Changes**. The PR cannot be merged as-is because the code is not compiled and contains critical functional defects. I will push fixes for these issues shortly.


### PR DESCRIPTION
This PR addresses critical issues identified in PR #68:
1.  **Dead Code**: The `vm` module was unlinked, meaning none of the security fixes were compiled. Linked it in `lib.rs` and `mod.rs`.
2.  **Fail-Open Firewall**: The firewall chain was created but never linked to system traffic. Added `link_chain` logic to `FirewallManager` to link to `FORWARD` chain when an interface is specified.
3.  **Broken Firecracker Integration**: Fixed missing imports and function signature mismatch in `firecracker.rs` that prevented compilation once linked. Added cross-platform stubs.
4.  **Code Quality**: Removed duplicate constants and tests in `seccomp.rs`.

Verified with `cargo check` and `cargo test` on Linux environment.
Includes `PR_REVIEW_68_JULES.md` with detailed analysis.

---
*PR created automatically by Jules for task [15466426317550395376](https://jules.google.com/task/15466426317550395376) started by @anchapin*