### PR TITLE
fix: Link VM module and resolve compilation errors

### DIFF
--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -4,3 +4,4 @@
 //! including MCP client implementation, VM spawning, and memory management.
 
 pub mod mcp;
+pub mod vm;

--- a/orchestrator/src/vm/config.rs
+++ b/orchestrator/src/vm/config.rs
@@ -2,8 +2,8 @@
 //
 // Firecracker VM configuration for secure agent execution
 
-use serde::{Deserialize, Serialize};
 use crate::vm::seccomp::SeccompFilter;
+use serde::{Deserialize, Serialize};
 
 /// VM configuration for Firecracker
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/orchestrator/src/vm/firecracker.rs
+++ b/orchestrator/src/vm/firecracker.rs
@@ -24,6 +24,7 @@ use tracing::{debug, info};
 use crate::vm::config::VmConfig;
 
 /// Firecracker VM process manager
+#[derive(Debug)]
 pub struct FirecrackerProcess {
     pub pid: u32,
     pub socket_path: String,
@@ -146,8 +147,10 @@ pub async fn start_firecracker(config: &VmConfig) -> Result<FirecrackerProcess> 
     info!("VM {} started in {:.2}ms", config.vm_id, spawn_time_ms);
 
     Ok(FirecrackerProcess {
-        pid: 0,
-        socket_path: "/tmp/firecracker.sock".to_string(),
+        pid,
+        socket_path,
+        child_process: Some(child),
+        spawn_time_ms,
     })
 }
 

--- a/orchestrator/src/vm/firewall.rs
+++ b/orchestrator/src/vm/firewall.rs
@@ -48,6 +48,19 @@ impl FirewallManager {
         Self { vm_id, chain_name }
     }
 
+    /// FNV-1a hash implementation
+    fn fnv1a_hash(text: &str) -> u32 {
+        let mut hash: u32 = 0x811c9dc5;
+        let prime: u32 = 0x01000193;
+
+        for byte in text.bytes() {
+            hash ^= byte as u32;
+            hash = hash.wrapping_mul(prime);
+        }
+
+        hash
+    }
+
     /// Configure firewall rules to isolate the VM
     ///
     /// This creates a new iptables chain and configures rules to:

--- a/orchestrator/src/vm/seccomp.rs
+++ b/orchestrator/src/vm/seccomp.rs
@@ -226,8 +226,7 @@ impl SeccompFilter {
             }
         });
 
-        serde_json::to_string_pretty(&filter)
-            .context("Failed to serialize seccomp filter")
+        serde_json::to_string_pretty(&filter).context("Failed to serialize seccomp filter")
     }
 }
 
@@ -272,12 +271,7 @@ impl SeccompAuditLog {
     }
 
     /// Log a blocked syscall
-    pub async fn log_blocked_syscall(
-        &self,
-        vm_id: &str,
-        syscall: &str,
-        pid: u32,
-    ) -> Result<()> {
+    pub async fn log_blocked_syscall(&self, vm_id: &str, syscall: &str, pid: u32) -> Result<()> {
         let entry = SeccompAuditEntry {
             vm_id: vm_id.to_string(),
             syscall: syscall.to_string(),
@@ -306,7 +300,10 @@ impl SeccompAuditLog {
                 vm_id, count
             );
         } else {
-            debug!("Blocked syscall in VM {}: {} (count: {})", vm_id, syscall, count);
+            debug!(
+                "Blocked syscall in VM {}: {} (count: {})",
+                vm_id, syscall, count
+            );
         }
 
         Ok(())
@@ -390,7 +387,10 @@ pub fn validate_seccomp_rules(filter: &SeccompFilter) -> Result<()> {
         }
     }
 
-    info!("Seccomp filter validation passed: {} syscalls allowed", whitelist.len());
+    info!(
+        "Seccomp filter validation passed: {} syscalls allowed",
+        whitelist.len()
+    );
 
     Ok(())
 }
@@ -415,12 +415,11 @@ mod tests {
 
     #[test]
     fn test_seccomp_filter_add_rule() {
-        let filter = SeccompFilter::default()
-            .add_rule(SyscallRule {
-                name: "test_syscall".to_string(),
-                action: SeccompAction::Allow,
-                rationale: "For testing".to_string(),
-            });
+        let filter = SeccompFilter::default().add_rule(SyscallRule {
+            name: "test_syscall".to_string(),
+            action: SeccompAction::Allow,
+            rationale: "For testing".to_string(),
+        });
 
         assert_eq!(filter.custom_rules.len(), 1);
         assert_eq!(filter.custom_rules[0].name, "test_syscall");
@@ -615,8 +614,14 @@ mod tests {
         let basic_count = basic.build_whitelist().len();
         let perm_count = permissive.build_whitelist().len();
 
-        assert!(min_count < basic_count, "Minimal should be smaller than Basic");
-        assert!(basic_count < perm_count, "Basic should be smaller than Permissive");
+        assert!(
+            min_count < basic_count,
+            "Minimal should be smaller than Basic"
+        );
+        assert!(
+            basic_count < perm_count,
+            "Basic should be smaller than Permissive"
+        );
     }
 
     // Property-based test: ensure minimal contains required syscalls
@@ -630,7 +635,11 @@ mod tests {
             let required = ["read", "write", "exit", "exit_group", "mmap"];
 
             for sys in &required {
-                assert!(whitelist.contains(&sys), "Required syscall {} not found in whitelist", sys);
+                assert!(
+                    whitelist.contains(&sys),
+                    "Required syscall {} not found in whitelist",
+                    sys
+                );
             }
         }
     }
@@ -643,23 +652,27 @@ mod tests {
 
         // These syscalls MUST NOT be allowed for security
         let dangerous = [
-            "socket",    // Network operations
-            "bind",      // Network operations
-            "listen",    // Network operations
-            "connect",   // Network operations
-            "clone",     // Process creation
-            "fork",      // Process creation
-            "vfork",     // Process creation
-            "execve",    // Execute programs
-            "mount",     // Filesystem mounting
-            "umount",    // Filesystem operations
-            "reboot",    // System reboot
-            "ptrace",    // Process tracing
+            "socket",     // Network operations
+            "bind",       // Network operations
+            "listen",     // Network operations
+            "connect",    // Network operations
+            "clone",      // Process creation
+            "fork",       // Process creation
+            "vfork",      // Process creation
+            "execve",     // Execute programs
+            "mount",      // Filesystem mounting
+            "umount",     // Filesystem operations
+            "reboot",     // System reboot
+            "ptrace",     // Process tracing
             "kexec_load", // Load new kernel
         ];
 
         for sys in &dangerous {
-            assert!(!whitelist.contains(&sys), "Dangerous syscall {} should be blocked", sys);
+            assert!(
+                !whitelist.contains(&sys),
+                "Dangerous syscall {} should be blocked",
+                sys
+            );
         }
     }
 }


### PR DESCRIPTION
The CI failure was caused by the `vm` module being unlinked from the crate, causing tests to be skipped and coverage to drop. Additionally, the `vm` module contained compilation errors (missing struct fields, missing method implementation, invalid module declarations) that were hidden because it wasn't being compiled.

This PR:
1.  Links the `vm` module in `lib.rs`.
2.  Fixes all compilation errors in the `vm` module.
3.  Restores coverage by enabling `vm` tests.
4.  Ensures `make test` passes.

---
*PR created automatically by Jules for task [9586442002568105419](https://jules.google.com/task/9586442002568105419) started by @anchapin*