### PR TITLE
🧹 Fix unused exception variables in McpClient.__exit__

### DIFF
--- a/agent/mcp_client.py
+++ b/agent/mcp_client.py
@@ -146,7 +146,7 @@ class McpClient:
             raise McpError("All command arguments must be strings")
 
         # Check for shell metacharacters that could enable injection
-        shell_metachars = [';', '&', '|', '$', '`', '(', ')', '<', '>', '\n', '\r']
+        shell_metachars = [";", "&", "|", "$", "`", "(", ")", "<", ">", "\n", "\r"]
         for arg in command:
             if any(char in arg for char in shell_metachars):
                 raise McpError(
@@ -158,13 +158,14 @@ class McpClient:
         # This is not a security boundary (the subprocess runs locally as the user),
         # but prevents accidental mistakes and documents expected commands.
         safe_commands = {
-            'npx',           # Node.js package runner
-            'python', 'python3',  # Python interpreters
-            'node',          # Node.js runtime
-            'cargo',         # Rust toolchain (for testing)
-            'echo',          # Testing (benign)
-            'true',          # Testing (benign)
-            'cat',           # File operations (for trusted input)
+            "npx",  # Node.js package runner
+            "python",
+            "python3",  # Python interpreters
+            "node",  # Node.js runtime
+            "cargo",  # Rust toolchain (for testing)
+            "echo",  # Testing (benign)
+            "true",  # Testing (benign)
+            "cat",  # File operations (for trusted input)
         }
 
         base_cmd = command[0]
@@ -174,10 +175,11 @@ class McpClient:
         if base_name not in safe_commands:
             # Log warning but don't fail - user may have custom setup
             import sys
+
             print(
                 f"Warning: Command '{base_name}' not in known-safe list. "
                 f"Ensure this command is trusted and does not accept untrusted input.",
-                file=sys.stderr
+                file=sys.stderr,
             )
 
         return command
@@ -419,7 +421,7 @@ class McpClient:
         self.initialize()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
         """Context manager exit"""
         self.shutdown()
         return False


### PR DESCRIPTION
Simple Python code quality improvement: Renames unused exception parameters in McpClient.__exit__ to use underscore prefix convention.