### PR TITLE
Fix compilation errors on main blocking PR merges

### DIFF
--- a/orchestrator/src/vm/e2e_tests.rs
+++ b/orchestrator/src/vm/e2e_tests.rs
@@ -186,10 +186,10 @@ async fn e2e_agent_with_security_features() {
     println!("  Spawned in {:.2}ms", start.elapsed().as_millis());
     destroy_vm(handle).await.unwrap();
 
-    // Test 2: Advanced seccomp
-    println!("\nTest 2: VM with Advanced seccomp");
-    let mut config = VmConfig::new("security-advanced".to_string());
-    config.seccomp_filter = Some(SeccompFilter::new(SeccompLevel::Advanced));
+    // Test 2: Permissive seccomp
+    println!("\nTest 2: VM with Permissive seccomp");
+    let mut config = VmConfig::new("security-permissive".to_string());
+    config.seccomp_filter = Some(SeccompFilter::new(SeccompLevel::Permissive));
 
     let start = Instant::now();
     let handle = match spawn_vm_with_config("security-advanced", &config).await {
@@ -202,10 +202,10 @@ async fn e2e_agent_with_security_features() {
     println!("  Spawned in {:.2}ms", start.elapsed().as_millis());
     destroy_vm(handle).await.unwrap();
 
-    // Test 3: Strict seccomp
-    println!("\nTest 3: VM with Strict seccomp");
-    let mut config = VmConfig::new("security-strict".to_string());
-    config.seccomp_filter = Some(SeccompFilter::new(SeccompLevel::Strict));
+    // Test 3: Minimal seccomp
+    println!("\nTest 3: VM with Minimal seccomp");
+    let mut config = VmConfig::new("security-minimal".to_string());
+    config.seccomp_filter = Some(SeccompFilter::new(SeccompLevel::Minimal));
 
     let start = Instant::now();
     let handle = match spawn_vm_with_config("security-strict", &config).await {
@@ -289,8 +289,6 @@ async fn e2e_agent_pool_warmup() {
                 println!("Pool status:");
                 println!("  Current size: {}", stats.current_size);
                 println!("  Max size: {}", stats.max_size);
-                println!("  Active VMs: {}", stats.active_vms);
-                println!("  Queued tasks: {}", stats.queued_tasks);
             }
         }
         Err(e) => {

--- a/orchestrator/src/vm/firecracker.rs
+++ b/orchestrator/src/vm/firecracker.rs
@@ -384,15 +384,18 @@ mod tests {
                 let elapsed = start.elapsed();
                 println!("Firecracker started in {:.2}ms, PID: {}", elapsed.as_millis(), process.pid);
 
+                // Clone socket_path before moving process
+                let socket_path = process.socket_path.clone();
+
                 // Verify socket was created
-                assert!(std::path::Path::new(&process.socket_path).exists());
+                assert!(std::path::Path::new(&socket_path).exists());
 
                 // Stop the VM
                 stop_firecracker(process).await.unwrap();
                 println!("Firecracker stopped successfully");
 
                 // Verify socket was cleaned up
-                assert!(!std::path::Path::new(&process.socket_path).exists());
+                assert!(!std::path::Path::new(&socket_path).exists());
             }
             Err(e) => {
                 eprintln!("Failed to start Firecracker: {}", e);
@@ -470,14 +473,17 @@ mod tests {
         assert!(!process.socket_path.is_empty());
         assert!(process.spawn_time_ms > 0.0);
 
+        // Clone socket_path before moving process
+        let socket_path = process.socket_path.clone();
+
         // Verify socket exists
-        assert!(std::path::Path::new(&process.socket_path).exists());
+        assert!(std::path::Path::new(&socket_path).exists());
 
         // Stop
         stop_firecracker(process).await.unwrap();
 
         // Verify cleanup
-        assert!(!std::path::Path::new(&process.socket_path).exists());
+        assert!(!std::path::Path::new(&socket_path).exists());
 
         println!("Firecracker lifecycle test completed successfully");
     }
@@ -502,7 +508,7 @@ mod tests {
             return;
         }
 
-        let config = VmConfig {
+        let _config = VmConfig {
             vm_id: "perf-test-vm".to_string(),
             kernel_path: kernel_path.to_string(),
             rootfs_path: rootfs_path.to_string(),

--- a/orchestrator/src/vm/integration_tests.rs
+++ b/orchestrator/src/vm/integration_tests.rs
@@ -509,9 +509,8 @@ async fn test_real_pool_stats() {
 
     match result {
         Ok(stats) => {
-            println!("Pool stats: size={}/{}, active={}, queued={}",
-                stats.current_size, stats.max_size,
-                stats.active_vms, stats.queued_tasks);
+            println!("Pool stats: size={}/{}",
+                stats.current_size, stats.max_size);
 
             assert!(stats.max_size > 0);
         }
@@ -538,7 +537,7 @@ async fn test_real_pool_warmup() {
             // Check stats
             if let Ok(stats) = pool_stats().await {
                 println!("Pool size after warmup: {}/{}", stats.current_size, stats.max_size);
-                println!("Oldest snapshot: {}s, Newest snapshot: {}s",
+                println!("Oldest snapshot: {:?}s, Newest snapshot: {:?}s",
                     stats.oldest_snapshot_age_secs, stats.newest_snapshot_age_secs);
             }
         }
@@ -600,7 +599,7 @@ async fn test_real_vm_performance() {
     println!("  Max: {:.2}ms", max.as_millis());
 
     // Check against target
-    if avg.as_millis() > 200.0 {
+    if avg.as_millis() as f64 > 200.0 {
         println!("  ⚠️  Average exceeds 200ms target");
     } else {
         println!("  ✅ Average meets 200ms target");

--- a/orchestrator/src/vm/jailer/config.rs
+++ b/orchestrator/src/vm/jailer/config.rs
@@ -308,7 +308,6 @@ mod tests {
         assert!(args.contains(&"cpu.shares=2048".to_string()));
     }
 }
-}
 
 // Property-based tests with Proptest
 #[cfg(test)]

--- a/orchestrator/src/vm/jailer/tests.rs
+++ b/orchestrator/src/vm/jailer/tests.rs
@@ -23,7 +23,6 @@ mod tests {
                 println!("Tests requiring real Jailer will be skipped");
             }
         }
-        assert!(result.is_ok() || result.is_err()); // Always passes, just reports status
     }
 
     /// Test that jailer config validates correct IDs

--- a/orchestrator/src/vm/tests.rs
+++ b/orchestrator/src/vm/tests.rs
@@ -5,7 +5,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::vm::{destroy_vm, spawn_vm, verify_network_isolation};
+    use crate::vm::{destroy_vm, verify_network_isolation};
 
     /// Test that VM cannot be created with networking enabled
     #[tokio::test]
@@ -18,6 +18,7 @@ mod tests {
         let result = config.validate();
         assert!(result.is_err());
         assert!(result
+            .as_ref()
             .unwrap_err()
             .to_string()
             .contains("Networking MUST be disabled"));


### PR DESCRIPTION
Closes #167

## Problem

The main branch has multiple compilation errors that are blocking other PRs from merging cleanly.

## Changes

- Fix SeccompLevel variants (Advanced->Permissive, Strict->Minimal) in e2e_tests.rs
- Fix ownership/borrowing errors in firecracker.rs (clone socket_path before moving)
- Fix PoolStats field references (remove non-existent active_vms, queued_tasks)
- Fix Option<u64> format specifiers (use {:?} instead of {})
- Fix type mismatch in comparison (cast as_millis() to f64)
- Fix extra closing brace in jailer/config.rs
- Fix ownership error in jailer/tests.rs

## Testing

All tests pass:
- cargo test --lib: 226 passed, 0 failed, 44 ignored

This fixes the compilation errors on main that are causing merge conflicts in other PRs.