### PR TITLE
Add root README.md with installation and usage instructions (Issue #230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,128 @@
+# LuminaGuard
+
+A local-first Agentic AI runtime designed to provide secure agent execution through Just-in-Time (JIT) Micro-VMs.
+
+## What is LuminaGuard?
+
+LuminaGuard replaces the insecure "vibe coding" paradigm with rigorous "Agentic Engineering" - combining the usability of OpenClaw with the security of Nanoclaw.
+
+### Key Features
+
+- **Just-in-Time Micro-VMs**: Agents run in ephemeral Micro-VMs that are spawned on-demand and destroyed after task completion
+- **Native MCP Support**: Connects to any standard MCP Server (GitHub, Slack, Postgres, etc.)
+- **The Approval Cliff**: High-stakes actions require explicit human approval before execution
+- **Defense in Depth**: Multiple security layers including Rust memory safety, KVM virtualization, seccomp filters, and firewall isolation
+
+## Quick Start
+
+### Prerequisites
+
+- Rust 1.70+ 
+- Python 3.10+
+- Firecracker (for VM features)
+- Linux with KVM support
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/anchapin/LuminaGuard.git
+cd LuminaGuard
+
+# Install all dependencies
+make install
+
+# Run tests to verify setup
+make test
+```
+
+### Basic Usage
+
+#### Python Agent with MCP
+
+```python
+from mcp_client import McpClient
+
+# Connect to a filesystem MCP server
+with McpClient("filesystem", ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"]) as client:
+    tools = client.list_tools()
+    result = client.call_tool("read_file", {"path": "test.txt"})
+    print(f"Content: {result}")
+```
+
+#### Rust Orchestrator
+
+```rust
+use luminaguard_orchestrator::mcp::McpClient;
+
+let mut client = McpClient::connect_stdio(
+    "filesystem",
+    &["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+).await?;
+
+client.initialize().await?;
+let tools = client.list_tools().await?;
+```
+
+#### VM Spawning (Security)
+
+```rust
+use luminaguard_orchestrator::vm;
+
+let handle = vm::spawn_vm("my-task").await?;
+println!("VM {} spawned in {:.2}ms", handle.id, handle.spawn_time_ms);
+
+vm::destroy_vm(handle).await?;
+```
+
+## Architecture
+
+LuminaGuard uses a "Rust Wrapper, Python Brain" design:
+
+- **Orchestrator (Rust)**: Handles micro-VM spawning, MCP connections, and security
+- **Agent (Python)**: The reasoning loop for agent decision-making
+
+See [CLAUDE.md](CLAUDE.md) for detailed developer documentation.
+
+## Security: The Approval Cliff
+
+LuminaGuard implements a strict approval system:
+
+| Action Type | Description | Approval Required |
+|-------------|-------------|------------------|
+| Green | Reading files, searching, checking logs | No |
+| Red | Editing code, deleting files, sending emails | **Yes** |
+
+Before any Red action executes, users see a "Diff Card" showing exactly what will change.
+
+## Development
+
+```bash
+make test              # Run all tests
+make test-rust        # Run Rust tests only
+make test-python      # Run Python tests only
+make fmt              # Format code
+make lint             # Run linters
+```
+
+## Test Coverage
+
+[![Coverage](https://img.shields.io/badge/coverage-76%25-green)](#)
+
+| Component | Coverage | Target |
+|-----------|----------|--------|
+| Rust (Orchestrator) | 74.2% | 75.0% |
+| Python (Agent) | 78.0% | 75.0% |
+
+## License
+
+See [LICENSE](LICENSE) file.
+
+## Resources
+
+- [Developer Documentation](CLAUDE.md)
+- [Architecture Docs](docs/architecture/architecture.md)
+- [Testing Strategy](docs/testing/testing.md)
+- [Snapshot Pool Guide](docs/snapshot-pool-guide.md)
+- [Security Validation](docs/validation/security-validation-plan.md)
+- [MCP Protocol](https://modelcontextprotocol.io)


### PR DESCRIPTION
## Summary

Created user-facing README.md at project root with:
- What is LuminaGuard overview
- Quick start guide
- Installation instructions
- Basic usage examples for Python and Rust
- Links to CLAUDE.md for developers
- Coverage badge placeholder

## Acceptance Criteria

- [x] README.md exists at root
- [x] Installation instructions work
- [x] Basic usage example provided
- [x] Links to detailed documentation

Closes #230