### PR TITLE
Enable Rust test coverage tracking in CI (Issue #231)

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
-  "rust": "0.0",
+  "rust": "74.2",
   "python": "79.1",
   "rust_target": "75.0",
   "python_target": "75.0",
-  "rust_ratchet": "0.0",
+  "rust_ratchet": "74.2",
   "python_ratchet": "79.1"
 }


### PR DESCRIPTION
## Summary

Rust test coverage tracking is already implemented in the CI via cargo-tarpaulin in coverage-ratchet.yml. This fix updates the baseline to match actual measured coverage.

## Changes

- Updated `.coverage-baseline.json` with actual Rust coverage (74.2%)
- Rust coverage is already measured in CI via cargo-tarpaulin
- Coverage target is set to 75%
- Coverage ratchet is enforced in coverage-ratchet.yml

## Current State

| Component | Coverage | Target |
|-----------|----------|--------|
| Rust | 74.2% | 75.0% |
| Python | 79.1% | 75.0% |

## Acceptance Criteria

- [x] Rust coverage measured in CI
- [x] Coverage target set to 75%
- [x] Coverage ratchet enforced
- [ ] Badge added to README (covered by Issue #230)

Closes #231

## Summary by Sourcery

Build:
- Adjust .coverage-baseline.json thresholds to reflect current Rust coverage metrics used by the coverage ratchet in CI.