### PR TITLE
Fix failing test: vm::chaos::tests::test_cpu_throttler_enable_disable (Issue #243)

### DIFF
--- a/orchestrator/src/vm/chaos.rs
+++ b/orchestrator/src/vm/chaos.rs
@@ -673,7 +673,7 @@ impl ChaosTestHarness {
 
         // Create CPU throttler (10-50ms random delays)
         let throttler = CpuThrottler::new(10, 50);
-        throttler.enable();
+        throttler.enable().await;
 
         let mut total_operations = 0;
         let mut successful_operations = 0;
@@ -909,7 +909,7 @@ impl ChaosTestHarness {
         chaos_monkey.enable();
 
         let throttler = CpuThrottler::new(5, 25); // 5-25ms delays
-        throttler.enable();
+        throttler.enable().await;
 
         let pressure_sim = MemoryPressureSimulator::new(512 * 1024, 5 * 1024 * 1024, 5); // 0.5-5MB
         pressure_sim.enable();
@@ -1059,7 +1059,7 @@ impl ChaosTestHarness {
         chaos_monkey.enable();
 
         let throttler = CpuThrottler::new(5, 20); // 5-20ms delays
-        throttler.enable();
+        throttler.enable().await;
 
         let mut total_operations = 0;
         let mut successful_operations = 0;
@@ -1346,7 +1346,7 @@ mod tests {
     #[tokio::test]
     async fn test_cpu_throttler_enable_disable() {
         let throttler = CpuThrottler::new(10, 50);
-        throttler.enable();
+        throttler.enable().await;
         assert!(throttler.is_enabled());
 
         throttler.disable();


### PR DESCRIPTION
## Summary
The test \`test_cpu_throttler_enable_disable\` was failing because \`CpuThrottler::enable()\` is an async function but was being called without \`.await\`. This caused the \`is_enabled()\` check to run before the \`enable()\` future was actually polled.

## Fix
Added \`.await\` to all \`throttler.enable()\` calls in the chaos.rs file (4 locations).

## Changes
- \`orchestrator/src/vm/chaos.rs\`: Added \`.await\` to 4 \`throttler.enable()\` calls

## Testing
The fix ensures the async enable() function is properly awaited before checking the enabled state.

Fixes #243