### PR TITLE
docs: Mark HTTP MCP transport as implemented

### DIFF
--- a/orchestrator/.beads/metrics/security-validation-report.json
+++ b/orchestrator/.beads/metrics/security-validation-report.json
@@ -4,88 +4,88 @@
       "test_name": "privilege_escalation_setuid",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 265.26453300000003,
+      "execution_time_ms": 0.02752,
       "details": "Blocked 10/10 setuid-related syscalls"
     },
     {
       "test_name": "privilege_escalation_capability_bypass",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 11.015015,
+      "execution_time_ms": 0.0062,
       "details": "Blocked 3/3 capability-related syscalls"
     },
     {
       "test_name": "filesystem_escape_mount",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 21.309452999999998,
+      "execution_time_ms": 0.00625,
       "details": "Blocked 4/4 mount-related syscalls"
     },
     {
       "test_name": "filesystem_escape_bind",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 9.695441,
+      "execution_time_ms": 0.0039700000000000004,
       "details": "Verifies bind syscall is blocked"
     },
     {
       "test_name": "network_escape_socket",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 27.669709,
+      "execution_time_ms": 0.00325,
       "details": "Verifies socket syscall is blocked"
     },
     {
       "test_name": "network_escape_bind_port",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 130.514184,
+      "execution_time_ms": 0.00327,
       "details": "Verifies bind syscall is blocked"
     },
     {
       "test_name": "network_escape_connect",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 27.322636,
+      "execution_time_ms": 0.00262,
       "details": "Verifies connect syscall is blocked"
     },
     {
       "test_name": "process_fork_bomb",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 46.031341000000005,
+      "execution_time_ms": 0.005370000000000001,
       "details": "Blocked 4/4 process creation syscalls"
     },
     {
       "test_name": "process_ptrace",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 45.370014,
+      "execution_time_ms": 0.00296,
       "details": "Verifies ptrace syscall is blocked"
     },
     {
       "test_name": "system_config_reboot",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 25.984632,
+      "execution_time_ms": 0.00319,
       "details": "Verifies reboot syscall is blocked"
     },
     {
       "test_name": "system_config_kexec",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 11.555581,
+      "execution_time_ms": 0.003,
       "details": "Verifies kexec_load syscall is blocked"
     },
     {
       "test_name": "system_config_acpi",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 20.472734,
+      "execution_time_ms": 0.005501000000000001,
       "details": "Blocked 4/4 hardware I/O syscalls"
     }
   ],
   "total_tests": 12,
   "blocked_count": 12,
-  "total_time_ms": 1178.384069
+  "total_time_ms": 0.094411
 }

--- a/orchestrator/.beads/metrics/security-validation-summary.txt
+++ b/orchestrator/.beads/metrics/security-validation-summary.txt
@@ -4,6 +4,6 @@ Total Tests: 12
 Blocked: 12
 Failed: 0
 Security Score: 100.0%
-Execution Time: 1178.38ms
+Execution Time: 0.09ms
 
 ✅ ALL ESCAPE ATTEMPTS BLOCKED - SYSTEM SECURE

--- a/orchestrator/.beads/metrics/security/security-validation-report.json
+++ b/orchestrator/.beads/metrics/security/security-validation-report.json
@@ -4,88 +4,88 @@
       "test_name": "privilege_escalation_setuid",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 265.265204,
+      "execution_time_ms": 0.02635,
       "details": "Blocked 10/10 setuid-related syscalls"
     },
     {
       "test_name": "privilege_escalation_capability_bypass",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 11.014965,
+      "execution_time_ms": 0.00541,
       "details": "Blocked 3/3 capability-related syscalls"
     },
     {
       "test_name": "filesystem_escape_mount",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 21.309533,
+      "execution_time_ms": 0.00574,
       "details": "Blocked 4/4 mount-related syscalls"
     },
     {
       "test_name": "filesystem_escape_bind",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 9.695841,
+      "execution_time_ms": 0.004019999999999999,
       "details": "Verifies bind syscall is blocked"
     },
     {
       "test_name": "network_escape_socket",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 27.654999,
+      "execution_time_ms": 0.0020099999999999996,
       "details": "Verifies socket syscall is blocked"
     },
     {
       "test_name": "network_escape_bind_port",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 130.499644,
+      "execution_time_ms": 0.00179,
       "details": "Verifies bind syscall is blocked"
     },
     {
       "test_name": "network_escape_connect",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 36.093077,
+      "execution_time_ms": 0.00173,
       "details": "Verifies connect syscall is blocked"
     },
     {
       "test_name": "process_fork_bomb",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 46.009121,
+      "execution_time_ms": 0.00392,
       "details": "Blocked 4/4 process creation syscalls"
     },
     {
       "test_name": "process_ptrace",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 38.857737,
+      "execution_time_ms": 0.00174,
       "details": "Verifies ptrace syscall is blocked"
     },
     {
       "test_name": "system_config_reboot",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 25.757529,
+      "execution_time_ms": 0.00164,
       "details": "Verifies reboot syscall is blocked"
     },
     {
       "test_name": "system_config_kexec",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 9.087334,
+      "execution_time_ms": 0.00157,
       "details": "Verifies kexec_load syscall is blocked"
     },
     {
       "test_name": "system_config_acpi",
       "blocked": true,
       "error_message": null,
-      "execution_time_ms": 13.452871,
+      "execution_time_ms": 0.00352,
       "details": "Blocked 4/4 hardware I/O syscalls"
     }
   ],
   "total_tests": 12,
   "blocked_count": 12,
-  "total_time_ms": 1181.6195229999998
+  "total_time_ms": 0.07658999999999999
 }

--- a/orchestrator/.beads/metrics/security/security-validation-summary.txt
+++ b/orchestrator/.beads/metrics/security/security-validation-summary.txt
@@ -4,6 +4,6 @@ Total Tests: 12
 Blocked: 12
 Failed: 0
 Security Score: 100.0%
-Execution Time: 1181.62ms
+Execution Time: 0.08ms
 
 ✅ ALL ESCAPE ATTEMPTS BLOCKED - SYSTEM SECURE

--- a/orchestrator/src/mcp/transport.rs
+++ b/orchestrator/src/mcp/transport.rs
@@ -4,7 +4,7 @@
 //! Multiple transports are supported:
 //!
 //! - **stdio**: Standard input/output (for local MCP servers)
-//! - **HTTP**: HTTP/HTTPS (for remote MCP servers) - TODO: Phase 2
+//! - **HTTP**: HTTP/HTTPS (for remote MCP servers) - IMPLEMENTED
 //!
 //! # Architecture
 //!


### PR DESCRIPTION
## Summary

The HTTP transport for MCP is already fully implemented in `http_transport.rs`. This PR updates the outdated TODO comment in `transport.rs` to reflect that status.

## Changes

- Updated comment in `transport.rs` from `TODO: Phase 2` to `IMPLEMENTED`

## Testing

All 379 tests pass.