### PR TITLE
Fix #339: macOS compilation for apple_hv module

### DIFF
--- a/orchestrator/src/vm/apple_hv.rs
+++ b/orchestrator/src/vm/apple_hv.rs
@@ -36,6 +36,9 @@ use crate::vm::hypervisor::{Hypervisor, VmInstance};
 // On actual macOS, these would bind to the real framework
 #[cfg(target_os = "macos")]
 mod vz_bindings {
+    use std::path::PathBuf;
+    use anyhow::Result;
+
     // NOTE: These are placeholder types representing the real Virtualization.framework API.
     // When building on macOS with proper bindings, these would be the actual types.
     // For now, we use stubs that match the API shape.


### PR DESCRIPTION
## Summary

Fixes compilation errors on macOS for the `orchestrator/src/vm/apple_hv.rs` module.

## Changes

- Added `PathBuf` import to `vz_bindings` module
- Added `Result` import to `vz_bindings` module

These imports were missing inside the `#[cfg(target_os = macos)]` vz_bindings module, causing compilation failures on macOS.

## Issue

#339: Rust apple_hv module fails to compile on macOS

This resolves:
- cannot find type 'PathBuf' in this scope - missing import in vz_bindings module
- enum takes 2 generic arguments but 1 generic argument was supplied - Result type issue

## Testing

\`cargo check\` passes on Linux. Full macOS CI will validate the fix.