### PR TITLE
fix: Remove unused imports in test modules

### DIFF
--- a/orchestrator/src/vm/approval_cliff_tests.rs
+++ b/orchestrator/src/vm/approval_cliff_tests.rs
@@ -19,7 +19,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 /// Result of a single approval test
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/orchestrator/src/vm/seccomp_tests.rs
+++ b/orchestrator/src/vm/seccomp_tests.rs
@@ -16,9 +16,8 @@
 // 6. Audit Logging Verification
 
 use serde::{Deserialize, Serialize};
-use std::process::Command;
 use std::time::Instant;
-use tracing::{debug, info, warn};
+use tracing::info;
 
 /// Result of a single seccomp test
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Remove unused imports in test modules to eliminate compiler warnings.

## Changes

1. **orchestrator/src/vm/approval_cliff_tests.rs**: Remove unused `warn` import from tracing
2. **orchestrator/src/vm/seccomp_tests.rs**: Remove unused `warn`, `debug`, and `std::process::Command` imports

## Testing

- [x] cargo check passes
- [x] All tests pass