### PR TITLE
feat(cli): Add interactive chat mode (issue #370)

### DIFF
--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -233,7 +233,7 @@ async fn chat_mode() -> Result<()> {
     // Spawn VM once for the session (for efficiency)
     info!("⚡ Spawning JIT Micro-VM for chat session...");
     let task_id = format!("chat-{}", session_id);
-    let handle = match vm::spawn_vm(&task_id).await {
+    let mut handle = match vm::spawn_vm(&task_id).await {
         Ok(h) => {
             println!("✅ VM ready (spawn time: {:.2}ms)", h.spawn_time_ms);
             Some(h)


### PR DESCRIPTION
## Summary
Adds interactive chat mode to the LuminaGuard CLI, allowing users to have multiple exchanges with the agent in a single session.

## Changes
- Added new \`luminaguard chat\` command
- Implemented chat loop with session management
- VM is spawned once and reused across messages for efficiency
- Added built-in commands:
  - \`help\` - Show available commands
  - \`quit/exit/bye\` - Exit chat mode
  - \`clear\` - Clear screen
  - \`status\` - Show session status
  - \`spawn\` - (Re)spawn the VM
  - \`kill\` - Destroy the VM
  - \`tools\` - Show MCP tools info

## Acceptance Criteria
- [x] Users can enter interactive mode with \`luminaguard chat\`
- [x] Prompts are sent to agent
- [x] Results are displayed clearly
- [x] Works over SSH (no GUI required)

## Related Issue
Fixes #370