### PR TITLE
Fix issue #386: Download and configure Firecracker VM resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,10 @@ tarpaulin-report.json
 
 # FPF (Formal Proof Framework) - local vibe coding context, not tracked
 .quint/
+
+# VM Resources - Large binaries downloaded from external sources
+# These are fetched by scripts/download-firecracker-resources.sh
+resources/
+orchestrator/resources/*.ext4
+orchestrator/resources/vmlinux
+/tmp/luminaguard-fc-test/

--- a/scripts/download-firecracker-resources.sh
+++ b/scripts/download-firecracker-resources.sh
@@ -11,8 +11,8 @@ echo "Downloading Firecracker resources to: $TARGET_DIR"
 # Create target directory
 mkdir -p "$TARGET_DIR"
 
-# Download kernel image (v4.14 from Firecracker releases)
-KERNEL_URL="https://s3.amazonaws.com/spec.ccfc.min/img/kiwi-no-dash.img"
+# Download kernel image (x86_64 vmlinux from Firecracker quickstart)
+KERNEL_URL="https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin"
 KERNEL_FILE="$TARGET_DIR/vmlinux.bin"
 
 if [ -f "$KERNEL_FILE" ]; then
@@ -20,18 +20,14 @@ if [ -f "$KERNEL_FILE" ]; then
 else
     echo "Downloading kernel image..."
     wget -q -O "$KERNEL_FILE" "$KERNEL_URL" || {
-        echo "Failed to download kernel. Trying alternative..."
-        # Fallback: try different URL
-        wget -q -O "$KERNEL_FILE" "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/vmlinux" || {
-            echo "ERROR: Could not download kernel image"
-            exit 1
-        }
+        echo "ERROR: Could not download kernel image"
+        exit 1
     }
     echo "Kernel downloaded: $KERNEL_FILE"
 fi
 
-# Download rootfs image (Ubuntu minimal)
-ROOTFS_URL="https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/0-rootfs.ext4"
+# Download rootfs image (Ubuntu bionic from Firecracker quickstart)
+ROOTFS_URL="https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4"
 ROOTFS_FILE="$TARGET_DIR/rootfs.ext4"
 
 if [ -f "$ROOTFS_FILE" ]; then
@@ -39,11 +35,8 @@ if [ -f "$ROOTFS_FILE" ]; then
 else
     echo "Downloading rootfs image..."
     wget -q -O "$ROOTFS_FILE" "$ROOTFS_URL" || {
-        echo "Failed to download rootfs. Trying alternative..."
-        wget -q -O "$ROOTFS_FILE" "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs.ext4" || {
-            echo "ERROR: Could not download rootfs image"
-            exit 1
-        }
+        echo "ERROR: Could not download rootfs image"
+        exit 1
     }
     echo "Rootfs downloaded: $ROOTFS_FILE"
 fi


### PR DESCRIPTION
## Summary
Fixes issue #386 - Firecracker VM resources were not available.

## Changes
1. **Updated download script** (`scripts/download-firecracker-resources.sh`): Fixed broken URLs with working ones from spec.ccfc.min S3 bucket:
   - Kernel: `s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin`
   - Rootfs: `s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4`

2. **Updated .gitignore**: Added entries to exclude large VM binary files from version control

## Testing
- ✅ `cargo run --bin luminaguard -- spawn-vm` works (VM spawns in ~28ms)
- ✅ All 15 VM tests pass: `cargo test --lib vm::tests`
- ✅ Download script verified working with custom target directory

## Notes
- Resources are downloaded to `/tmp/luminaguard-fc-test/` by default
- For development, resources are also available in `orchestrator/resources/`
- Run `./scripts/download-firecracker-resources.sh` to fetch resources