### PR TITLE
fix: Address dead code detection issues from CI (issue 400)

### DIFF
--- a/agent/messenger/__init__.py
+++ b/agent/messenger/__init__.py
@@ -10,6 +10,16 @@ Architecture:
 - Message routing and handling is abstracted
 """
 
+__all__ = [
+    "BotEvent",
+    "EventType",
+    "Message",
+    "MessageType",
+    "MessengerBot",
+    "MessengerConnector",
+    "MessageRouter",
+]
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/agent/messenger/telegram.py
+++ b/agent/messenger/telegram.py
@@ -294,8 +294,6 @@ class TelegramConnector(MessengerConnector):
                     message_type = MessageType.TEXT
                     break
 
-        from datetime import datetime
-
         msg = Message(
             id=str(message.get("message_id", "")),
             chat_id=str(message.get("chat", {}).get("id", "")),

--- a/agent/tests/test_vsock_client.py
+++ b/agent/tests/test_vsock_client.py
@@ -8,7 +8,7 @@ import sys
 import os
 import json
 import struct
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import MagicMock, mock_open, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 


### PR DESCRIPTION
## Summary

This PR addresses the CI failure reported in issue 400 regarding dead code detection failing on PR #399.

## Changes

1. **Add `__all__` to messenger/__init__.py**: This fixes the "undecidable case" warning from pycln. When pycln can't determine if imports are used (like in `__init__.py` files that export symbols), adding `__all__` makes it clear which names are intended to be public.

2. **Remove unused datetime import in telegram.py**: The `from datetime import datetime` was imported but never actually used in the `_parse_message` method.

3. **Minor import cleanup in test_vsock_client.py**: Just reordering imports alphabetically.

## CI Analysis

The original CI failure on PR #399 had two issues:
1. **Dead Code Detection failure**: pycln found unused imports in various files
2. **Exit code 128**: This was a false alarm - it was caused by git submodule cleanup issues during post-job cleanup (the error was `fatal: No url found for submodule path '.worktrees-pr/pr-179' in .gitmodules`)

This PR fixes the actual dead code issues, and the submodule issue appears to be a transient CI infrastructure problem.

## Testing

- [x] Code compiles without errors
- [x] All existing tests pass
- [x] pycln --check passes locally (note: may need Python 3.11 for full compatibility)

## Summary by Sourcery

Resolve CI dead code detection failures by cleaning up unused imports and clarifying public exports in the messenger package.

Bug Fixes:
- Remove an unused datetime import in the Telegram messenger implementation to satisfy dead code checks.

Enhancements:
- Define explicit public exports in the messenger package __init__ to avoid undecidable import usage warnings from static analysis tools.
- Tidy test import ordering in the vsock client tests to align with style and tooling expectations.