### PR TITLE
fix: Skip VSOCK tests in CI environments (#426)

### DIFF
--- a/agent/conftest.py
+++ b/agent/conftest.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Pytest configuration for agent tests.
+
+This module provides fixtures and configuration for running tests,
+including skipping tests that require VSOCK when not available.
+"""
+
+import pytest
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers", "vsock: tests that require VSOCK to be available"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Automatically skip tests that require VSOCK when running in CI
+    or when VSOCK is not available.
+    """
+    # Import here to avoid import errors if vsock_client is not available
+    try:
+        from vsock_client import is_ci_environment, is_vsock_available
+    except ImportError:
+        # If we can't import, assume we're not in CI and VSOCK is available
+        return
+    
+    skip_vsock = pytest.mark.skip(
+        reason="VSOCK not available in CI environment"
+    )
+    
+    for item in items:
+        # Check if the test requires VSOCK
+        # This could be via marker or test name
+        if "vsock" in item.name.lower() or "vm_mode" in item.name.lower():
+            # Check if we're in CI or VSOCK is not available
+            if is_ci_environment() or not is_vsock_available():
+                item.add_marker(skip_vsock)

--- a/agent/vsock_client.py
+++ b/agent/vsock_client.py
@@ -16,6 +16,50 @@ import sys
 from typing import Dict, Optional
 
 
+def is_ci_environment() -> bool:
+    """
+    Check if we're running in a CI environment.
+    
+    Returns:
+        True if running in CI, False otherwise.
+    """
+    # Check common CI environment variables
+    ci_vars = [
+        "CI",  # Generic CI flag
+        "GITHUB_ACTIONS",  # GitHub Actions
+        "GITLAB_CI",  # GitLab CI
+        "JENKINS_URL",  # Jenkins
+        "CIRCLECI",  # CircleCI
+        "TRAVIS",  # Travis CI
+        "TWISTED",  # Twisted (for testing)
+        "CONTINUOUS_INTEGRATION",  # Generic
+    ]
+    return any(os.environ.get(var) for var in ci_vars)
+
+
+def is_vsock_available() -> bool:
+    """
+    Check if VSOCK socket is available (socket file exists).
+    
+    This function checks if the default or configured VSOCK socket
+    exists. If running in CI, this will return False since VSOCK
+    devices are typically not available in CI environments.
+    
+    Returns:
+        True if VSOCK is available, False otherwise.
+    """
+    # In CI environments, VSOCK is typically not available
+    if is_ci_environment():
+        return False
+    
+    # Check if socket file exists
+    socket_path = os.environ.get(
+        "LUMINAGUARD_VSOCK_PATH", 
+        "/tmp/luminaguard/vsock/host.sock"
+    )
+    return os.path.exists(socket_path)
+
+
 class VsockClient:
     """Client for communicating with host orchestrator via vsock/Unix socket"""
 


### PR DESCRIPTION
## Summary

This PR fixes issue #426 by adding VSOCK availability detection for CI environments.

## Changes

- Add `is_ci_environment()` function to detect CI environments via environment variables
- Add `is_vsock_available()` function to check if VSOCK socket exists
- Add `conftest.py` with pytest hook to automatically skip VSOCK-dependent tests in CI

## Testing

- Verified locally that functions work correctly
- Tests will now be skipped in CI where VSOCK device is not available

Closes #426