### PR TITLE
fix(rust): Fix doctest import path in network_partition_tests.rs

### DIFF
--- a/orchestrator/src/vm/network_partition_tests.rs
+++ b/orchestrator/src/vm/network_partition_tests.rs
@@ -24,7 +24,7 @@ use crate::vm::network_partition::{
 /// # Example
 ///
 /// ```no_run
-/// use luminaguard_orchestrator::vm::run_network_partition_tests;
+/// use luminaguard_orchestrator::vm::network_partition_tests::run_network_partition_tests;
 ///
 /// #[tokio::main]
 /// async fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

Fix the Rust doctest compilation failure in `network_partition_tests.rs`.

## Problem

The doctest was referencing the wrong module path:
- Before: `luminaguard_orchestrator::vm::run_network_partition_tests`
- After: `luminaguard_orchestrator::vm::network_partition_tests::run_network_partition_tests`

This caused the doctest to fail with:
```
error[E0432]: import `luminaguard_orchestrator::vm::run_network_partition_tests` not found
```

## Solution

Update the doctest example to use the correct fully qualified module path.

## Testing

- `cargo test` now passes (8 passed, 0 failed)

Closes #405