### PR TITLE
[#518] Implement CLI argument parsing with clap

### DIFF
--- a/orchestrator/src/metrics.rs
+++ b/orchestrator/src/metrics.rs
@@ -276,18 +276,18 @@ mod tests {
         assert!(result.is_ok());
 
         let metrics_text = result.unwrap();
-        
+
         // The registry may be empty if metrics weren't registered (e.g., if init() was
         // already called by another test). In that case, we just verify the function works.
         // On Windows, there can be timing issues with lazy_static initialization.
-        // 
+        //
         // If metrics are registered, check for expected metric names.
         // If registry is empty, just verify we got valid output (empty string is valid).
         if !metrics_text.is_empty() {
             // Check for metric names (they may have luminaguard_ prefix depending on registry)
             // Note: metric names include underscores: vm_spawn_time_seconds, active_vms_total, etc.
             assert!(
-                metrics_text.contains("vm_spawn_time") 
+                metrics_text.contains("vm_spawn_time")
                     || metrics_text.contains("active_vms")
                     || metrics_text.contains("vms_spawned")
                     || metrics_text.contains("memory_usage")


### PR DESCRIPTION
## Summary

Implements CLI argument parsing using clap derive API for LuminaGuard orchestrator.

## Changes

- Added `status` command - Shows LuminaGuard system status (VM pool, active sessions, version info, environment)
- Added `config` command with subcommands:
  - `show` - Displays current VM configuration and environment variables
  - `validate` - Validates configuration
  - `reset` - Shows information about resetting to defaults
- Added comprehensive help text for all commands
- Implemented argument validation

## Testing

- 16 comprehensive unit tests added (all passing)
- Commands verified manually:
  - `luminaguard --help` - Shows all available commands
  - `luminaguard status` - Displays system status
  - `luminaguard config --help` - Shows config subcommands
  - `luminaguard config show` - Displays configuration
  - `luminaguard config validate` - Validates configuration

## Acceptance Criteria

- [x] Add clap dependency to Cargo.toml (already present)
- [x] Implement CLI using clap derive API
- [x] Support subcommands: run, status, config
- [x] Add comprehensive help text
- [x] Add argument validation
- [x] Add CLI tests

Closes #518